### PR TITLE
Use data endpoint and use ports 80 and 443

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,9 @@ var logFactory = require('docker-loghose');
 function connect(opts) {
   var stream;
   if (opts.secure) {
-    stream = tls.connect(20000, 'api.logentries.com', onSecure);
+    stream = tls.connect(443, 'data.logentries.com', onSecure);
   } else {
-    stream = net.createConnection(10000, 'api.logentries.com');
+    stream = net.createConnection(80, 'data.logentries.com');
   }
 
   function onSecure() {


### PR DESCRIPTION
We should not be using api.logentries.com for Token based inputs. Use data.logentries.com as it accepts data over ports 80 and 443 which are more likely to be open then ports 10000 and 20000