### PR TITLE
Filtering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # docker-logentries
 #
-# VERSION 0.1.0
+# VERSION 0.2.0
 
-FROM node:0.10-onbuild
+FROM node:0.12-onbuild
 MAINTAINER Matteo Collina <hello@matteocollina.com>
 
 ENTRYPOINT ["/usr/src/app/index.js"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ You can also pass the `--no-stats` flag if you do not want stats to be
 published to logentries every second. You __need this flag for Docker
 version < 1.5__.
 
+You can also pass the `--no-logs` flag if you do not want logs to be
+published to logentries.
+
+You can also filter filter the containers for whitch the logs/stats are
+forwarded with:
+
+* `--matchByName REGEXP`: forward logs/stats only for the containers whose name matches the given REGEXP.
+* `--matchByImage REGEXP`: forward logs/stats only for the containers whose image matches the given REGEXP.
+* `--skipByName REGEXP`: do not forward logs/stats for the containers whose name matches the given REGEXP.
+* `--skipByImage REGEXP`: do not forward logs/stats for the containers whose image matches the given REGEXP.
+
 ## Usage as a CLI
 
 1. `npm install docker-logentries -g`
@@ -36,6 +47,14 @@ You can also pass the `--no-stats` flag if you do not want stats to be
 published to logentries every second.
 The `-a/--add` flag allows to add fixed values to the data being
 published. This follows the format 'name=value'.
+
+You can also filter filter the containers for whitch the logs/stats are
+forwarded with:
+
+* `--matchByName REGEXP`: forward logs/stats only for the containers whose name matches the given REGEXP.
+* `--matchByImage REGEXP`: forward logs/stats only for the containers whose image matches the given REGEXP.
+* `--skipByName REGEXP`: do not forward logs/stats for the containers whose name matches the given REGEXP.
+* `--skipByImage REGEXP`: do not forward logs/stats for the containers whose image matches the given REGEXP.
 
 ## Embedded usage
 
@@ -50,6 +69,13 @@ var logentries = require('docker-logentries')({
   token: process.env.TOKEN, // logentries TOKEN
   stats: true, // disable stats if false
   add: null, // an object whose properties will be added
+
+  // the following options limit the containers being matched
+  // so we can avoid catching logs for unwanted containers
+  matchByName: /hello/, // optional
+  matchByImage: /matteocollina/, //optional
+  skipByName: /.*pasteur.*/, //optional
+  skipByImage: /.*dockerfile.*/ //optional
 })
 
 // logentries is the source stream with all the

--- a/index.js
+++ b/index.js
@@ -46,14 +46,23 @@ function start(opts) {
     cb()
   });
   var events = allContainers(opts);
+  var loghose;
+  var stats;
+
   opts.events = events;
 
-  var loghose = logFactory(opts);
-  loghose.pipe(filter);
+  if (opts.logs !== false) {
+    loghose = logFactory(opts);
+    loghose.pipe(filter);
+  }
 
   if (opts.stats !== false) {
-    var stats = statsFactory(opts);
+    stats = statsFactory(opts);
     stats.pipe(filter);
+  }
+
+  if (!stats && !logs) {
+    throw new Error('you should enable stats, logs or both')
   }
 
   pipe();
@@ -105,6 +114,7 @@ function cli() {
     default: {
       json: false,
       stats: true,
+      logs: true,
       add: []
     }
   });
@@ -112,7 +122,10 @@ function cli() {
   if (!(argv.token || (argv.logstoken && argv.statstoken))) {
     console.log('Usage: docker-logentries [-l LOGSTOKEN] [-k STATSTOKEN]\n' +
                 '                         [-t TOKEN] [--secure] [--json]\n' +
-                '                         [--no-stats] [-a KEY=VALUE]');
+                '                         [--no-stats] [--no-logs] [-a KEY=VALUE]\n' +
+                '                         [--matchByImage REGEXP] [--matchByName REGEXP]\n' +
+                '                         [--skipByImage REGEXP] [--skipByName REGEXP]');
+
     process.exit(1);
   }
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "author": "Matteo Collina <matteo.collina@nearform.com>",
   "license": "MIT",
   "dependencies": {
-    "docker-allcontainers": "^0.2.0",
-    "docker-loghose": "^0.4.0",
-    "docker-stats": "^0.2.0",
+    "docker-allcontainers": "^0.3.0",
+    "docker-loghose": "^0.5.0",
+    "docker-stats": "^0.3.0",
     "end-of-stream": "^1.1.0",
     "minimist": "^1.1.0",
     "through2": "^0.6.3"


### PR DESCRIPTION
Added some options for filtering:

* `--matchByName REGEXP`: forward logs/stats only for the containers whose name matches the given REGEXP.
* `--matchByImage REGEXP`: forward logs/stats only for the containers whose image matches the given REGEXP.
* `--skipByName REGEXP`: do not forward logs/stats for the containers whose name matches the given REGEXP.
* `--skipByImage REGEXP`: do not forward logs/stats for the containers whose image matches the given REGEXP.

It also updates node in the Dockerfile to 0.12.

@Maxim-Filimonov @siniar1990 @jcugno can you please test it?

Closes #13.