### PR TITLE
LOG-19529 Adding github team name to codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@logsearch-dev-tools-cop
+* @rapid7/dublin-dev-tools-cop


### PR DESCRIPTION
## Issue

Link to Jira ticket:  [LOG-19529](https://issues.corp.rapid7.com/browse/LOG-19529)

## Purpose of PR

Add dev-tools-cop team to codeowners file